### PR TITLE
Potential fix for code scanning alert no. 36: Missing space in string concatenation

### DIFF
--- a/src/pages/oppdrag/BestilleSkattekortButton.tsx
+++ b/src/pages/oppdrag/BestilleSkattekortButton.tsx
@@ -56,7 +56,7 @@ export default function BestilleSkattekortButton(
 					props.setAlertMessage({
 						message:
 							"Skattekort bestilles fra Skatteetaten. Det tar normalt et par minutter." +
-							"Du kan lukke dette vinduet eller fortsette å arbeide i mellomtiden.",
+							" Du kan lukke dette vinduet eller fortsette å arbeide i mellomtiden.",
 						variant: "success",
 					});
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/sokos-up-oppdragsinfo/security/code-scanning/36](https://github.com/navikt/sokos-up-oppdragsinfo/security/code-scanning/36)

General fix: when splitting user-facing text across concatenated string literals, ensure either the first part ends with a space or the next part starts with one.

Best fix here (without changing functionality): in `src/pages/oppdrag/BestilleSkattekortButton.tsx`, update the concatenated success message so there is a space between `"minutter."` and `"Du..."`. The minimal and clearest change is to add a leading space to the second literal.

No imports, methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
